### PR TITLE
Fix dep to work on node 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,21 +14,21 @@
     "vue": "^2.6.10",
     "vue-echarts": "^4.1.0",
     "vue-router": "^3.1.3",
-    "vuetify": "^2.1.0"
+    "vuetify": "^2.2.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.0",
     "@vue/cli-plugin-eslint": "^4.1.0",
     "@vue/cli-plugin-router": "^4.1.2",
     "@vue/cli-service": "^4.1.0",
-    "babel-eslint": "^10.0.3",
-    "eslint": "^5.16.0",
-    "eslint-plugin-vue": "^5.0.0",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
+    "eslint-plugin-vue": "^6.2.2",
     "sass": "^1.19.0",
     "sass-loader": "^8.0.0",
     "vue-cli-plugin-vuetify": "^2.0.3",
     "vue-template-compiler": "^2.6.10",
-    "vuetify-loader": "^1.3.0"
+    "vuetify-loader": "^1.4.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/assets/js/parser.js
+++ b/src/assets/js/parser.js
@@ -81,6 +81,7 @@ export default class Parser {
                 if (unit.type === "Char") {
                     result = await this.parseCommand(unit, "read");
                     let append = false;
+                    /* eslint-disable no-prototype-builtins */
                     if (unit.hasOwnProperty('append')) {
                         append = unit.append;
                     }


### PR DESCRIPTION
Also bump of eslint harden rules, so an esint disable is required in the
sor parsing lib.

BTW, this is great work, I was thinking of writing such a lib myself !! After a quick test, no error is display when loading an incorrect file, I'll try to do a PR if I have time.